### PR TITLE
Agregar conexión a MongoDB e inicializar al iniciar

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,9 @@
-const app = require("./src/app")
+const app = require("./src/app");
+const connectDB = require("./src/config/db");
 
 const port = 3000;
+
+connectDB();
 
 app.listen(port, () => {
 console.log(`Servidor corriendo en puerto http://localhost:${port}`);

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,0 +1,13 @@
+const mongoose = require("mongoose");
+
+const connectDB = async () => {
+    try{
+        await mongoose.connect("mongodb://localhost:27017");
+        console.log("Conexion exitosa con la base de datos");
+    }catch (error) {
+        console.error("Error conectando a la base de datos: ", error.message);
+        process.exit(1);
+    }
+};
+
+module.exports = connectDB;


### PR DESCRIPTION
Agrega una nueva configuración de base de datos basada en mongoose (backend/src/config/db.js) que se conecte a mongodb://localhost:27017 con registro de éxito/error y salida del proceso en caso de fallo. Requiere e invoca connectDB() en backend/server.js antes de iniciar el listener de la aplicación para que el servidor solo se inicie después de la inicialización de la base de datos.

Closes #54 